### PR TITLE
Fix failing tests for firstOrCreate, firstOrNew and PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "codeception/module-phpbrowser": "*@dev",
         "slevomat/coding-standard": "^6.2",
         "squizlabs/php_codesniffer": "*",
-        "phpoption/phpoption": "^1.8.0"
+        "phpoption/phpoption": "^1.8.0",
+        "symfony/http-foundation": "^5.3.7 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "slevomat/coding-standard": "^6.2",
         "squizlabs/php_codesniffer": "*",
         "phpoption/phpoption": "^1.8.0",
-        "symfony/http-foundation": "^5.3.7 || ^6.0"
+        "symfony/http-foundation": "^5.3.7 || ^6.0",
+        "ramsey/collection": "^1.2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "codeception/module-filesystem": "^3.0",
         "codeception/module-phpbrowser": "*@dev",
         "slevomat/coding-standard": "^6.2",
-        "squizlabs/php_codesniffer": "*"
+        "squizlabs/php_codesniffer": "*",
+        "phpoption/phpoption": "^1.8.0"
     },
     "autoload": {
         "psr-4": {

--- a/stubs/EloquentBuilder.stubphp
+++ b/stubs/EloquentBuilder.stubphp
@@ -168,6 +168,20 @@ class Builder
     public function firstOr($columns = ['*'], Closure $callback = null) { }
 
     /**
+     * @param  array  $attributes
+     * @param  array  $values
+     * @return TModel|self<TModel>
+     */
+    public function firstOrNew(array $attributes = [], array $values = []) { }
+
+    /**
+     * @param  array  $attributes
+     * @param  array  $values
+     * @return TModel|self<TModel>
+     */
+    public function firstOrCreate(array $attributes = [], array $values = []) { }
+
+    /**
      * @param  string  $column
      * @return mixed
      */

--- a/stubs/HasOneOrMany.stubphp
+++ b/stubs/HasOneOrMany.stubphp
@@ -66,4 +66,20 @@ abstract class HasOneOrMany extends Relation
      * @psalm-return \Illuminate\Database\Eloquent\Collection<TRelatedModel>
      */
     public function createMany(array $records) { }
+
+    /**
+     * @param  array  $attributes
+     * @param  array  $values
+     * @return \Illuminate\Database\Eloquent\Model
+     * @psalm-return TRelatedModel
+     */
+    public function firstOrNew(array $attributes = [], array $values = []) { }
+
+    /**
+     * @param  array  $attributes
+     * @param  array  $values
+     * @return \Illuminate\Database\Eloquent\Model
+     * @psalm-return TRelatedModel
+     */
+    public function firstOrCreate(array $attributes = [], array $values = []) { }
 }

--- a/tests/acceptance/EloquentBuilderTypes.feature
+++ b/tests/acceptance/EloquentBuilderTypes.feature
@@ -178,7 +178,7 @@ Feature: Eloquent Builder types
     Then I see no errors
 
   Scenario: can call firstOrNew and firstOrCreate without parameters in Laravel 8.x
-    Given I have the "laravel/framework" package satisfying the ">= 8.0"
+    Given I have the "laravel/framework" package satisfying the "^8.0"
     And I have the following code
     """
     /**
@@ -194,6 +194,29 @@ Feature: Eloquent Builder types
     * @psalm-return User
     */
     function test_firstOrNew(Builder $builder): User {
+      return $builder->firstOrNew();
+    }
+    """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: can call firstOrNew and firstOrCreate without parameters in Laravel 9.x
+    Given I have the "laravel/framework" package satisfying the "^9.0"
+    And I have the following code
+    """
+    /**
+    * @psalm-param Builder<User> $builder
+    * @psalm-return Builder<User>|User
+    */
+    function test_firstOrCreate(Builder $builder): Builder|User {
+      return $builder->firstOrCreate();
+    }
+
+    /**
+    * @psalm-param Builder<User> $builder
+    * @psalm-return Builder<User>|User
+    */
+    function test_firstOrNew(Builder $builder): Builder|User {
       return $builder->firstOrNew();
     }
     """


### PR DESCRIPTION
I couldn't come up with a better solution for the PHP 8.1 failures than to require-dev working versions of the packages.